### PR TITLE
크기 및 레이아웃 조정

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,13 +1,18 @@
+body, html {
+    width: 100%;
+    margin: 0;
+}
 body {
     background-color:rgb(100, 82, 97);
-    overflow-x: hidden;
 }
 
 h1 {
-    position:relative;
-    left: 50%;
-    margin-left: -500px;
-    margin-top: 5px;
+    margin: 0;
+    text-align: center;
+}
+h1 img {
+    width: 100%;
+    max-width: 1000px;
 }
 
 #footer {
@@ -21,17 +26,18 @@ h1 {
 }
 
 #pannel {
-    position: relative;
-    width: 102%;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 150px);
+    justify-content: center;
 }
 
 img {
     -webkit-user-drag: none;
-    min-width: 200px;
+    min-width: 150px;
 }
 
 img.thumnail {
-    width: 200px;
+    width: 150px;
     border-radius: 10%;
 }
 


### PR DESCRIPTION
FHD 모니터에서 메이플스토리 클라이언트 해상도를 1024x768로 설정하고 게임과 족보 페이지를 겹치지 안도록 모니터 양쪽에 배치했을 때 모든 섬네일 이미지가 표시되도록 사이즈 조절 및 레이아웃 개선

![SharedScreenshot](https://user-images.githubusercontent.com/21959564/126030156-2eb181f3-7bba-4d72-af58-05a71b207bb1.jpg)
